### PR TITLE
add prepublishOnly to the 2 templates that were missing it for consistency with the 4 others

### DIFF
--- a/minimal/package.json
+++ b/minimal/package.json
@@ -16,8 +16,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "dev": "tsdown --watch",
-    "prepublishOnly": "pnpm run build"
+    "dev": "tsdown --watch"
   },
   "devDependencies": {
     "tsdown": "^0.16.0"


### PR DESCRIPTION
consistency + helps with not forgetting to build

*although maybe this should be prepack instead of prepublishOnly in ALL cases? idk