### PR TITLE
fix(vite-plus): remove `include` field in tsconfig

### DIFF
--- a/vite-plus/tsconfig.json
+++ b/vite-plus/tsconfig.json
@@ -16,6 +16,5 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true
-  },
-  "include": ["src"]
+  }
 }


### PR DESCRIPTION
- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.
  - [ ] I understand that my PR is more likely to be rejected or requested for changes if it contains AI-generated code that I do not fully understand.

According to oxc-project/tsgolint#845 and voidzero-dev/vite-plus#1104.  `tsgolint` (used for type checking) creates an inferred program for files which don't match any `tsconfig.json` (including files explicitly excluded), means these files will be still type checked, but outside of the original tsconfig context.

This could cause complex problems, like type leaking and different behaviors between `vp staged` and `vp check`. 

Since this is [a design decision](https://github.com/oxc-project/tsgolint/issues/845#issuecomment-4177839244) from upstream, it might be worth reconsidering how the template defines type-check boundaries (e.g. whether the current `include` setting aligns with the actual behavior), to help new users avoid unexpected issues.